### PR TITLE
Add DeregisterExtension endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ type ExtensionManager interface {
 	Call(registry, item string, req osquery.ExtensionPluginRequest) (*osquery.ExtensionResponse, error)
 	Extensions() (osquery.InternalExtensionList, error)
 	RegisterExtension(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error)
+	DeregisterExtension(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error)
 	Options() (osquery.InternalOptionList, error)
 	Query(sql string) (*osquery.ExtensionResponse, error)
 	GetQueryColumns(sql string) (*osquery.ExtensionResponse, error)
@@ -71,6 +72,11 @@ func (c *ExtensionManagerClient) Extensions() (osquery.InternalExtensionList, er
 // RegisterExtension registers the extension plugins with the osquery process.
 func (c *ExtensionManagerClient) RegisterExtension(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error) {
 	return c.Client.RegisterExtension(context.Background(), info, registry)
+}
+
+// DeregisterExtension de-registers the extension plugins with the osquery process.
+func (c *ExtensionManagerClient) DeregisterExtension(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error) {
+	return c.Client.DeregisterExtension(context.Background(), uuid)
 }
 
 // Options requests the list of bootstrap or configuration options.

--- a/mock_manager.go
+++ b/mock_manager.go
@@ -16,6 +16,8 @@ type ExtensionsFunc func() (osquery.InternalExtensionList, error)
 
 type RegisterExtensionFunc func(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error)
 
+type DeregisterExtensionFunc func(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error)
+
 type OptionsFunc func() (osquery.InternalOptionList, error)
 
 type QueryFunc func(sql string) (*osquery.ExtensionResponse, error)
@@ -37,6 +39,9 @@ type MockExtensionManager struct {
 
 	RegisterExtensionFunc        RegisterExtensionFunc
 	RegisterExtensionFuncInvoked bool
+
+	DeRegisterExtensionFunc        DeregisterExtensionFunc
+	DeRegisterExtensionFuncInvoked bool
 
 	OptionsFunc        OptionsFunc
 	OptionsFuncInvoked bool
@@ -71,6 +76,11 @@ func (m *MockExtensionManager) Extensions() (osquery.InternalExtensionList, erro
 func (m *MockExtensionManager) RegisterExtension(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error) {
 	m.RegisterExtensionFuncInvoked = true
 	return m.RegisterExtensionFunc(info, registry)
+}
+
+func (m *MockExtensionManager) DeregisterExtension(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error) {
+	m.DeRegisterExtensionFuncInvoked = true
+	return m.DeRegisterExtensionFunc(uuid)
 }
 
 func (m *MockExtensionManager) Options() (osquery.InternalOptionList, error) {

--- a/server_test.go
+++ b/server_test.go
@@ -36,6 +36,10 @@ func TestNoDeadlockOnError(t *testing.T) {
 		PingFunc: func() (*osquery.ExtensionStatus, error) {
 			return &osquery.ExtensionStatus{}, nil
 		},
+		DeRegisterExtensionFunc: func(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error) {
+			return &osquery.ExtensionStatus{}, nil
+		},
+		CloseFunc: func() {},
 	}
 	server := &ExtensionManagerServer{
 		serverClient: mock,
@@ -70,6 +74,10 @@ func TestShutdownWhenPingFails(t *testing.T) {
 			// As if the socket was closed
 			return nil, syscall.EPIPE
 		},
+		DeRegisterExtensionFunc: func(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error) {
+			return &osquery.ExtensionStatus{}, nil
+		},
+		CloseFunc: func() {},
 	}
 	server := &ExtensionManagerServer{
 		serverClient: mock,
@@ -79,6 +87,8 @@ func TestShutdownWhenPingFails(t *testing.T) {
 	err := server.Run()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "broken pipe")
+	assert.True(t, mock.DeRegisterExtensionFuncInvoked)
+	assert.True(t, mock.CloseFuncInvoked)
 }
 
 // How many parallel tests to run (because sync issues do not occur on every
@@ -104,6 +114,10 @@ func testShutdownDeadlock(t *testing.T) {
 		RegisterExtensionFunc: func(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error) {
 			return &osquery.ExtensionStatus{Code: 0, UUID: retUUID}, nil
 		},
+		DeRegisterExtensionFunc: func(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error) {
+			return &osquery.ExtensionStatus{}, nil
+		},
+		CloseFunc: func() {},
 	}
 	server := ExtensionManagerServer{serverClient: mock, sockPath: tempPath.Name()}
 
@@ -172,6 +186,10 @@ func TestShutdownBasic(t *testing.T) {
 		RegisterExtensionFunc: func(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error) {
 			return &osquery.ExtensionStatus{Code: 0, UUID: retUUID}, nil
 		},
+		DeRegisterExtensionFunc: func(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error) {
+			return &osquery.ExtensionStatus{}, nil
+		},
+		CloseFunc: func() {},
 	}
 	server := ExtensionManagerServer{serverClient: mock, sockPath: tempPath.Name()}
 


### PR DESCRIPTION
When the extension manager shuts down, osquery states it should
deregister.
When the extension is started again, having deregistered can avoid failures
when osquery starts the new process before the register watcher has had
time to remove the old extension from its map.