### PR TITLE
Add distributed query stats

### DIFF
--- a/plugin/distributed/distributed.go
+++ b/plugin/distributed/distributed.go
@@ -46,7 +46,7 @@ type Result struct {
 	// Rows is the result rows of the query.
 	Rows []map[string]string `json:"rows"`
 	// QueryStats are the stats about the execution of the given query
-	QueryStats Stats `json:"stats"`
+	QueryStats *Stats `json:"stats"`
 }
 
 // WriteResultsFunc writes the results of the executed distributed queries. The
@@ -203,7 +203,10 @@ func (rs *ResultsStruct) toResults() ([]Result, error) {
 			QueryName:  queryName,
 			Rows:       rows,
 			Status:     int(rs.Statuses[queryName]),
-			QueryStats: rs.Stats[queryName],
+			QueryStats: nil,
+		}
+		if stats, ok := rs.Stats[queryName]; ok {
+			result.QueryStats = &stats
 		}
 		results = append(results, result)
 	}

--- a/plugin/distributed/distributed.go
+++ b/plugin/distributed/distributed.go
@@ -45,6 +45,8 @@ type Result struct {
 	Status int `json:"status"`
 	// Rows is the result rows of the query.
 	Rows []map[string]string `json:"rows"`
+	// QueryStats are the stats about the execution of the given query
+	QueryStats Stats `json:"stats"`
 }
 
 // WriteResultsFunc writes the results of the executed distributed queries. The
@@ -139,6 +141,15 @@ func (oi *OsqueryInt) UnmarshalJSON(buff []byte) error {
 type ResultsStruct struct {
 	Queries  map[string][]map[string]string `json:"queries"`
 	Statuses map[string]OsqueryInt          `json:"statuses"`
+	Stats    map[string]Stats               `json:"stats"`
+}
+
+// Stats holds performance stats about the execution of a given query.
+type Stats struct {
+	WallTimeMs OsqueryInt `json:"wall_time_ms"`
+	UserTime   OsqueryInt `json:"user_time"`
+	SystemTime OsqueryInt `json:"system_time"`
+	Memory     OsqueryInt `json:"memory"`
 }
 
 // UnmarshalJSON turns structurally inconsistent osquery json into a ResultsStruct.
@@ -151,6 +162,7 @@ func (rs *ResultsStruct) UnmarshalJSON(buff []byte) error {
 	intermediate := struct {
 		Queries  map[string]interface{} `json:"queries"`
 		Statuses map[string]OsqueryInt  `json:"statuses"`
+		Stats    map[string]Stats       `json:"stats"`
 	}{}
 	if err := json.Unmarshal(buff, &intermediate); err != nil {
 		return err
@@ -179,6 +191,8 @@ func (rs *ResultsStruct) UnmarshalJSON(buff []byte) error {
 			return fmt.Errorf("results for %q unknown type", queryName)
 		}
 	}
+	// Stats don't require any format changes
+	rs.Stats = intermediate.Stats
 	return nil
 }
 
@@ -186,9 +200,10 @@ func (rs *ResultsStruct) toResults() ([]Result, error) {
 	var results []Result
 	for queryName, rows := range rs.Queries {
 		result := Result{
-			QueryName: queryName,
-			Rows:      rows,
-			Status:    int(rs.Statuses[queryName]),
+			QueryName:  queryName,
+			Rows:       rows,
+			Status:     int(rs.Statuses[queryName]),
+			QueryStats: rs.Stats[queryName],
 		}
 		results = append(results, result)
 	}

--- a/plugin/distributed/distributed_test.go
+++ b/plugin/distributed/distributed_test.go
@@ -56,16 +56,16 @@ func TestDistributedPlugin(t *testing.T) {
 
 	// Call writeResults
 	getCalled = false
-	resp = plugin.Call(context.Background(), osquery.ExtensionPluginRequest{"action": "writeResults", "results": `{"queries":{"query1":[{"iso_8601":"2017-07-10T22:08:40Z"}],"query2":[{"version":"2.4.0"}]},"statuses":{"query1":"0","query2":"0","query3":"1"}}`})
+	resp = plugin.Call(context.Background(), osquery.ExtensionPluginRequest{"action": "writeResults", "results": `{"queries":{"query1":[{"iso_8601":"2017-07-10T22:08:40Z"}],"query2":[{"version":"2.4.0"}]},"statuses":{"query1":"0","query2":"0","query3":"1"}, "stats":{"query1":{"wall_time_ms": 1, "user_time": 1, "system_time": 1, "memory": 1},"query2":{"wall_time_ms": 2, "user_time": 2, "system_time": 2, "memory": 2},"query3":{"wall_time_ms": 3, "user_time": 3, "system_time": 3, "memory": 3}}}`})
 	assert.False(t, getCalled)
 	assert.True(t, writeCalled)
 	assert.Equal(t, &StatusOK, resp.Status)
 	// Ensure correct ordering for comparison
 	sort.Slice(results, func(i, j int) bool { return results[i].QueryName < results[j].QueryName })
 	assert.Equal(t, []Result{
-		{"query1", 0, []map[string]string{{"iso_8601": "2017-07-10T22:08:40Z"}}},
-		{"query2", 0, []map[string]string{{"version": "2.4.0"}}},
-		{"query3", 1, []map[string]string{}},
+		{"query1", 0, []map[string]string{{"iso_8601": "2017-07-10T22:08:40Z"}}, Stats{WallTimeMs: 1, UserTime: 1, SystemTime: 1, Memory: 1}},
+		{"query2", 0, []map[string]string{{"version": "2.4.0"}}, Stats{WallTimeMs: 2, UserTime: 2, SystemTime: 2, Memory: 2}},
+		{"query3", 1, []map[string]string{}, Stats{WallTimeMs: 3, UserTime: 3, SystemTime: 3, Memory: 3}},
 	},
 		results)
 }

--- a/plugin/distributed/distributed_test.go
+++ b/plugin/distributed/distributed_test.go
@@ -63,9 +63,24 @@ func TestDistributedPlugin(t *testing.T) {
 	// Ensure correct ordering for comparison
 	sort.Slice(results, func(i, j int) bool { return results[i].QueryName < results[j].QueryName })
 	assert.Equal(t, []Result{
-		{"query1", 0, []map[string]string{{"iso_8601": "2017-07-10T22:08:40Z"}}, Stats{WallTimeMs: 1, UserTime: 1, SystemTime: 1, Memory: 1}},
-		{"query2", 0, []map[string]string{{"version": "2.4.0"}}, Stats{WallTimeMs: 2, UserTime: 2, SystemTime: 2, Memory: 2}},
-		{"query3", 1, []map[string]string{}, Stats{WallTimeMs: 3, UserTime: 3, SystemTime: 3, Memory: 3}},
+		{"query1", 0, []map[string]string{{"iso_8601": "2017-07-10T22:08:40Z"}}, &Stats{WallTimeMs: 1, UserTime: 1, SystemTime: 1, Memory: 1}},
+		{"query2", 0, []map[string]string{{"version": "2.4.0"}}, &Stats{WallTimeMs: 2, UserTime: 2, SystemTime: 2, Memory: 2}},
+		{"query3", 1, []map[string]string{}, &Stats{WallTimeMs: 3, UserTime: 3, SystemTime: 3, Memory: 3}},
+	},
+		results)
+
+	// Call writeResults -- no stats attached
+	getCalled = false
+	resp = plugin.Call(context.Background(), osquery.ExtensionPluginRequest{"action": "writeResults", "results": `{"queries":{"query1":[{"iso_8601":"2017-07-10T22:08:40Z"}],"query2":[{"version":"2.4.0"}]},"statuses":{"query1":"0","query2":"0","query3":"1"}}`})
+	assert.False(t, getCalled)
+	assert.True(t, writeCalled)
+	assert.Equal(t, &StatusOK, resp.Status)
+	// Ensure correct ordering for comparison
+	sort.Slice(results, func(i, j int) bool { return results[i].QueryName < results[j].QueryName })
+	assert.Equal(t, []Result{
+		{"query1", 0, []map[string]string{{"iso_8601": "2017-07-10T22:08:40Z"}}, nil},
+		{"query2", 0, []map[string]string{{"version": "2.4.0"}}, nil},
+		{"query3", 1, []map[string]string{}, nil},
 	},
 		results)
 }


### PR DESCRIPTION
Relates to https://github.com/kolide/launcher/issues/1147

Adds distributed query stats to results -- schema defined [here](https://github.com/osquery/osquery/blob/master/osquery/distributed/distributed.cpp#L107).