### PR TITLE
Wrapping ServerConnectivityCheckInterval() body in a mutex

### DIFF
--- a/server.go
+++ b/server.go
@@ -87,7 +87,10 @@ func ServerPingInterval(interval time.Duration) ServerOption {
 // interval used by connectivity check in thrift compiled TProcessorFunc implementations.
 // See the thrift docs for more information
 func ServerConnectivityCheckInterval(interval time.Duration) ServerOption {
-	return func(_ *ExtensionManagerServer) {
+	return func(s *ExtensionManagerServer) {
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+
 		thrift.ServerConnectivityCheckInterval = interval
 	}
 }


### PR DESCRIPTION
Since `serverConnectivityCheckInterval` is a package level variable, wrapping writes to it in a mutex prevents data races in testing code.