### PR TITLE
Allow for passing in an ExtensionManagerClient to NewExtensionManagerServer

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,18 +11,6 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 )
 
-type ExtensionManager interface {
-	Close()
-	Ping() (*osquery.ExtensionStatus, error)
-	Call(registry, item string, req osquery.ExtensionPluginRequest) (*osquery.ExtensionResponse, error)
-	Extensions() (osquery.InternalExtensionList, error)
-	RegisterExtension(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error)
-	DeregisterExtension(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error)
-	Options() (osquery.InternalOptionList, error)
-	Query(sql string) (*osquery.ExtensionResponse, error)
-	GetQueryColumns(sql string) (*osquery.ExtensionResponse, error)
-}
-
 // ExtensionManagerClient is a wrapper for the osquery Thrift extensions API.
 type ExtensionManagerClient struct {
 	Client    osquery.ExtensionManager


### PR DESCRIPTION
Spoke with @directionless -- started breaking apart https://github.com/osquery/osquery-go/pull/99 into smaller PRs. This PR handles adding the `WithClient` option to `NewExtensionManagerServer`, so that applications can reuse the same client for the client portions of server communication.