### PR TITLE
Set internal version for OpenTelemetry traces on initialization

### DIFF
--- a/traces/traces_test.go
+++ b/traces/traces_test.go
@@ -1,0 +1,27 @@
+package traces
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceInit(t *testing.T) {
+	t.Parallel()
+
+	// Start several spans in quick succession to confirm there's no data race on setting `internalVersion`
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i += 1 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, span := StartSpan(context.TODO(), "TestSpan")
+			span.End()
+		}()
+	}
+
+	wg.Wait()
+	assert.NotEmpty(t, internalVersion, "internal version should have been set")
+}


### PR DESCRIPTION
When I pulled in https://github.com/osquery/osquery-go/pull/110 to began using traces, I noticed that it was possible to have a data race when the first few spans created by a consuming application could be created at the same time. This PR fixes that issue and adds a test to confirm the fix as well.