### PR TITLE
Rename Table.Call span to table name instead

### DIFF
--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -54,7 +54,7 @@ func (t *Plugin) Routes() osquery.ExtensionPluginResponse {
 }
 
 func (t *Plugin) Call(ctx context.Context, request osquery.ExtensionPluginRequest) osquery.ExtensionResponse {
-	ctx, span := traces.StartSpan(ctx, "Table.Call", "action", request["action"], "table_name", t.name)
+	ctx, span := traces.StartSpan(ctx, t.name, "action", request["action"], "table_name", t.name)
 	defer span.End()
 
 	ok := osquery.ExtensionStatus{Code: 0, Message: "OK"}


### PR DESCRIPTION
Renaming the span from `Table.Call` to the table name allows for differentiating better between calls to different tables. (It is still possible to group all traces coming through the `Table.Call` function by e.g. searching for all traces with an `osquery-go.action` attribute.)